### PR TITLE
Basic Access Point mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 - `run-parts`
 - `mktemp`
 
+
+### Additional Requirements for Access Point Mode
+
+- `hostapd`
+- `dnsmasq`
+
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed

--- a/lib/nerves_network_ng.ex
+++ b/lib/nerves_network_ng.ex
@@ -31,4 +31,11 @@ defmodule Nerves.NetworkNG do
     Ethernet.write_config_file(ethernet)
     Ethernet.down()
   end
+
+  def run_cmd(command, args) do
+    case System.cmd(command, args, stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {error, 1} -> {:error, error}
+    end
+  end
 end

--- a/lib/nerves_network_ng/access_point.ex
+++ b/lib/nerves_network_ng/access_point.ex
@@ -1,0 +1,89 @@
+defmodule Nerves.NetworkNG.AccessPoint do
+  alias Nerves.NetworkNG.{HostAPD, WiFi, DNSMASQ}
+
+  defstruct interface: nil,
+            ssid: nil,
+            psk: nil,
+            address: nil,
+            dhcp_range_min: nil,
+            dhcp_range_max: nil,
+            netmask: nil,
+            network: nil,
+            broadcast: nil
+
+  def new(opts) do
+    struct(__MODULE__, opts)
+  end
+
+  def write_config_files(ap) do
+    with :ok <- config_wifi(ap),
+         :ok <- config_dnsmasq(ap),
+         :ok <- config_hostapd(ap) do
+      :ok
+    end
+  end
+
+  def up() do
+    with :ok <- WiFi.up(),
+         :ok <- DNSMASQ.run(),
+         :ok <- HostAPD.run() do
+      :ok
+    else
+      error -> error
+    end
+  end
+
+  def config_wifi(
+        %__MODULE__{
+          interface: interface,
+          ssid: ssid,
+          psk: psk,
+          address: address,
+          network: network,
+          netmask: netmask,
+          broadcast: broadcast
+        },
+        opts \\ []
+      ) do
+    opts =
+      [
+        address: address,
+        network: network,
+        netmask: netmask,
+        address_method: :static,
+        broadcast: broadcast
+      ]
+      |> Keyword.merge(opts)
+
+    interface
+    |> WiFi.new(ssid, psk, opts)
+    |> WiFi.write_config_file()
+  end
+
+  def config_hostapd(
+        %__MODULE__{
+          interface: interface,
+          ssid: ssid,
+          psk: psk
+        },
+        opts \\ []
+      ) do
+    interface
+    |> HostAPD.new(ssid, psk, opts)
+    |> HostAPD.write_config_file()
+  end
+
+  def config_dnsmasq(
+        %__MODULE__{
+          interface: interface,
+          address: address,
+          dhcp_range_min: dhcp_range_min,
+          dhcp_range_max: dhcp_range_max
+        },
+        opts \\ []
+      ) do
+    interface
+    |> DNSMASQ.new(address, dhcp_range_min, dhcp_range_max, opts)
+    |> DNSMASQ.write_config_file()
+  end
+end

--- a/lib/nerves_network_ng/dnsmasq.ex
+++ b/lib/nerves_network_ng/dnsmasq.ex
@@ -1,0 +1,84 @@
+defmodule Nerves.NetworkNG.DNSMASQ do
+  alias Nerves.NetworkNG
+
+  @type t :: %__MODULE__{}
+
+  defstruct interface: "wlan0",
+            listen_address: nil,
+            bind_interfaces: true,
+            server: "8.8.8.8",
+            domain_needed: true,
+            bogus_priv: true,
+            dhcp_range_min: nil,
+            dhcp_range_max: nil,
+            lease_time_hours: 12
+
+  def new(interface, listen_address, dhcp_range_min, dhcp_range_max, opts \\ []) do
+    opts =
+      [
+        interface: interface,
+        listen_address: listen_address,
+        dhcp_range_min: dhcp_range_min,
+        dhcp_range_max: dhcp_range_max
+      ]
+      |> Keyword.merge(opts)
+
+    struct(__MODULE__, opts)
+  end
+
+  def config_file_path() do
+    tmp_dir = NetworkNG.tmp_dir()
+    Path.join(tmp_dir, "dnsmasq.conf")
+  end
+
+  def to_config(
+        %__MODULE__{
+          interface: interface,
+          listen_address: listen_address,
+          server: server,
+          dhcp_range_min: dhcp_range_min,
+          dhcp_range_max: dhcp_range_max,
+          lease_time_hours: lease_time
+        } = dnsmasq
+      ) do
+    contents = """
+    interface=#{interface}
+    listen-address=#{listen_address}
+    server=#{server}
+    dhcp-range=#{dhcp_range_min},#{dhcp_range_max},#{lease_time}
+    """
+
+    bool_opts = get_active_opts(dnsmasq)
+
+    Enum.reduce(bool_opts, String.trim(contents), fn active_opt, config ->
+      config <> "\n#{active_opt}"
+    end)
+  end
+
+  @spec write_config_file(t()) :: :ok | {:error, File.posix()}
+  def write_config_file(dnsmasq) do
+    config_contents = to_config(dnsmasq)
+    :ok = NetworkNG.ensure_tmp_dir()
+
+    config_file_path()
+    |> File.write(config_contents)
+  end
+
+  def get_active_opts(dnsmasq) do
+    dnsmasq
+    |> Map.from_struct()
+    |> Enum.filter(&opt_active?/1)
+    |> Enum.map(fn {optname, _} -> opt_name_to_string(optname) end)
+  end
+
+  def run() do
+    NetworkNG.run_cmd("dnsmasq", ["-C", config_file_path()])
+  end
+
+  defp opt_active?({_, true}), do: true
+  defp opt_active?({_, _}), do: false
+
+  defp opt_name_to_string(:bind_interfaces), do: "bind-interfaces"
+  defp opt_name_to_string(:domain_needed), do: "domain-needed"
+  defp opt_name_to_string(:bogus_priv), do: "bogus-priv"
+end

--- a/lib/nerves_network_ng/hostapd.ex
+++ b/lib/nerves_network_ng/hostapd.ex
@@ -1,0 +1,48 @@
+defmodule Nerves.NetworkNG.HostAPD do
+  alias Nerves.NetworkNG
+
+  defstruct interface: nil,
+            driver: :nl80211,
+            ssid: nil,
+            hw_mode: "g",
+            channel: 6,
+            ieee80211n: 1,
+            wmm_enabled: 1,
+            ht_capab: "[HT40][SHORT-GI-20][DSSS_CCk-40]",
+            macaddr_acl: 0,
+            auth_algs: 1,
+            ignore_broadcast_ssid: 0,
+            wpa: 2,
+            wpa_key_mgmt: "WPA-PSK",
+            wpa_passphrase: nil,
+            rsn_pairwise: "CCMP"
+
+  def new(interface, ssid, psk, opts \\ []) do
+    opts = [interface: interface, ssid: ssid, wpa_passphrase: psk] |> Keyword.merge(opts)
+    struct(__MODULE__, opts)
+  end
+
+  def config_file_path() do
+    Path.join(NetworkNG.tmp_dir(), "hostapd.conf")
+  end
+
+  def to_config(hostapd) do
+    config = Map.from_struct(hostapd)
+
+    Enum.reduce(config, "", fn {config_name, config_value}, contents ->
+      contents <> "#{config_name}=#{config_value}\n"
+    end)
+  end
+
+  def run() do
+    NetworkNG.run_cmd("hostapd", [config_file_path(), "-B"])
+  end
+
+  def write_config_file(hostapd) do
+    contents = to_config(hostapd)
+    :ok = NetworkNG.ensure_tmp_dir()
+
+    config_file_path()
+    |> File.write(contents)
+  end
+end


### PR DESCRIPTION
Currently, I have Access Point writing all the configs mostly out of convenience in IEx, so we will probably want to change the API a little once we get LTE working, if we so desire.


Basic usage would look like:

```elixir

iex> my_opts =
  [
    interface: "wlan0",
    address: "192.168.50.1",
    ssid: "Nerves-AP",
    psk: "12345678",
    dhcp_range_min: "192.168.50.1",
    dhcp_range_max: "192.168.50.150",
    network: "192.168.50.0",
    broadcast: "192.168.50.255",
    netmask: "255.255.255.0
  ]


iex> my_opts |> AccessPoint.new() |> AccessPoint.write_config_files() |> AccessPoint.up()
```

Then it will bring up an AP named "Nerves-AP" that you can connect to with `12345678`, and send pings to `192.168.50.1` on the host machine.


Some areas we will need to improve and think about are:

1. Bring the AP mode down
1. Better config values?
1. Logging

I did not reall look into that stuff as to keep momentum with adding more networking technologies. After adding LTE we can visit some of that more and look into robustness of all the technologies, including AP mode. Let me know if you object and I can visit any areas you would like me to look at before moving onto LTE.