### PR TITLE
LTE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@
 - `hostapd`
 - `dnsmasq`
 
+### Addtional Requirements for LTE
+
+#### Kernel modules (defconfig)
+
+- `CONFIG_PPP=m`
+- `CONFIG_PPP_BSDCOMP=m`
+- `CONFIG_PPP_DEFLATE=m`
+- `CONFIG_PPP_ASYNC=m`
+- `CONFIG_PPP_SYNC_TTY=m`
+- `CONFIG_USB_NET_CDC_NCM=m`
+- `CONFIG_USB_NET_HUAWEI_CDC_NCM=m`
+- `CONFIG_USB_SERIAL_OPTION=m`
+
+#### System deps
+
+- `pppd`
+- `usb_modeswitch`
+
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed

--- a/lib/nerves_network_ng/pppd.ex
+++ b/lib/nerves_network_ng/pppd.ex
@@ -1,0 +1,99 @@
+defmodule Nerves.NetworkNG.PPPD do
+  @moduledoc """
+  Example with Twilio provider
+
+  iex> {:ok, pppd} = Nerves.NetworkNG.setup_with_provider(Nerves.NetworkNG.Twilio)
+  iex> Nerves.NetworkNG.up(pppd)
+  """
+  alias Nerves.NetworkNG
+
+  # probably will want to handle this differently long term
+  @default_pppd_options [noipdefault: true, usepeerdns: true, defaultroute: true, persist: true]
+
+  @opaque t :: %__MODULE__{
+            options: keyword(),
+            provider: module()
+          }
+
+  defstruct options: [],
+            provider: nil
+
+  @spec new(module(), pppd_options :: keyword()) :: t()
+  def new(provider_module, pppd_options \\ @default_pppd_options) do
+    struct(__MODULE__, provider: provider_module, options: pppd_options)
+  end
+
+  def run_usb_modeswitch() do
+    NetworkNG.run_cmd("usb_modeswitch", ["-v", "12d1", "-p", "14fe", "-J"])
+  end
+
+  @doc """
+  Takes the pppd provider module (make a behavior for this?) to set
+  up configuration file, runs usb mode switch for the LTE module, and
+  setups up kernel drivers
+
+  We return a new PPPD to use if setup works.
+  """
+  @spec setup_with_provider(module(), pppd_options :: keyword()) :: {:ok, t()} | any()
+  def setup_with_provider(provider_module, pppd_options \\ @default_pppd_options) do
+    with :ok <- run_usb_modeswitch(),
+         :ok <- setup_drivers(),
+         :ok <- apply(provider_module, :write_config, []) do
+      {:ok, new(provider_module, pppd_options)}
+    else
+      error -> error
+    end
+  end
+
+  @doc """
+  Start the pppd service.
+
+  Currently will always run the `usb_modeswitch` command, might want to pull that out
+  or make it configurable later.
+  """
+  @spec up(t()) :: integer()
+  def up(pppd) do
+    {_, exit_code} = System.cmd("sh", ["-c", to_cli_command(pppd)])
+    exit_code
+  end
+
+  @spec to_cli_command(t()) :: String.t()
+  def to_cli_command(%__MODULE__{provider: provider_module} = pppd) do
+    provider_config_file = apply(provider_module, :config_file_path, [])
+
+    command_str =
+      "pppd connect \"/usr/sbin/chat -v -f #{provider_config_file}\" /dev/ttyUSB0 115200"
+
+    pppd
+    |> to_option_list()
+    |> Enum.map(&option_to_string/1)
+    |> Enum.reduce(command_str, &(&2 <> " #{&1}"))
+  end
+
+  def setup_drivers() do
+    drivers = [
+      "huawei_cdc_ncm",
+      "option",
+      "bsd_comp",
+      "ppp_deflate"
+    ]
+
+    Enum.each(drivers, &System.cmd("modprobe", [&1]))
+  end
+
+  @spec to_option_list(t()) :: [atom()]
+  def to_option_list(%__MODULE__{options: opts}) do
+    opts
+    |> Enum.reduce([], fn
+      {opt_name, true}, acc -> acc ++ [opt_name]
+      {_, false}, acc -> acc
+    end)
+  end
+
+  @spec option_to_string(atom()) :: String.t()
+  defp option_to_string(:usepeerdns), do: "usepeerdns"
+  defp option_to_string(:defaultroute), do: "defaultroute"
+  defp option_to_string(:persist), do: "persist"
+  defp option_to_string(:noauth), do: "noauth"
+  defp option_to_string(:noipdefault), do: "noipdefault"
+end

--- a/lib/nerves_network_ng/twilio.ex
+++ b/lib/nerves_network_ng/twilio.ex
@@ -1,0 +1,51 @@
+defmodule Nerves.NetworkNG.Twilio do
+  alias Nerves.NetworkNG
+
+  def config_file_path() do
+    Path.join(NetworkNG.tmp_dir(), "twilio")
+  end
+
+  def config_contents() do
+    """
+    # See http://consumer.huawei.com/solutions/m2m-solutions/en/products/support/application-guides/detail/mu509-65-en.htm?id=82047
+
+    # Exit execution if module receives any of the following strings:
+    ABORT 'BUSY'
+    ABORT 'NO CARRIER'
+    ABORT 'NO DIALTONE'
+    ABORT 'NO DIAL TONE'
+    ABORT 'NO ANSWER'
+    ABORT 'DELAYED'
+    TIMEOUT 10
+    REPORT CONNECT
+
+    # Module will send the string AT regardless of the string it receives
+    "" AT
+
+    # Instructs the modem to disconnect from the line, terminating any call in progress. All of the functions of the command shall be completed before the modem returns a result code.
+    OK ATH
+
+    # Instructs the modem to set all parameters to the factory defaults.
+    OK ATZ
+
+    # Result codes are sent to the Data Terminal Equipment (DTE).
+    OK ATQ0
+
+    # Define PDP context
+    OK AT+CGDCONT=1,"IP","wireless.twilio.com"
+
+    # ATDT = Attention Dial Tone
+    OK ATDT*99***1#
+
+    # Don't send any more strings when it receives the string CONNECT. Module considers the data links as having been set up.
+    CONNECT ''
+    """
+  end
+
+  def write_config() do
+    :ok = NetworkNG.ensure_tmp_dir()
+
+    config_file_path()
+    |> File.write(config_contents())
+  end
+end


### PR DESCRIPTION
Much like the network technologies this one's API is not the greatest, and I make a lot of assumptions about how things are going to run which might be true in a general sense, however, this gives us some basic support for LTE with Twilio provider and Huawei USB modem. 

I am not sure if we need to do the `modprobe` call, but I had to on my custom Nerves system, but that could be due to lack of knowledge in that area.


```
iex> {:ok, pppd} = Nerves.NetworkNG.setup_with_provider(Nerves.NetworkNG.Twilio)
iex> Nerves.NetworkNG.up(pppd)
```