### PR TITLE
Get a list of interfaces

### DIFF
--- a/lib/nerves_network_ng.ex
+++ b/lib/nerves_network_ng.ex
@@ -1,5 +1,5 @@
 defmodule Nerves.NetworkNG do
-  alias Nerves.NetworkNG.Ethernet
+  alias Nerves.NetworkNG.{Ethernet, IP}
 
   @doc """
   Get the path to the nerves network tmp directory
@@ -36,6 +36,27 @@ defmodule Nerves.NetworkNG do
     case System.cmd(command, args, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {error, 1} -> {:error, error}
+    end
+  end
+
+  @doc """
+  Get a list of current interfaces
+  """
+  @spec interfaces() :: [String.t()]
+  def interfaces() do
+    case IP.link() do
+      {:ok, iplink_output} ->
+        regex = ~r/[a-z]\w+: /
+        ifaces = Regex.scan(regex, iplink_output)
+
+        ifaces
+        |> List.flatten()
+        |> Enum.map(fn iface ->
+          String.replace(iface, ": ", "")
+        end)
+
+      error ->
+        error
     end
   end
 end

--- a/lib/nerves_network_ng/ip.ex
+++ b/lib/nerves_network_ng/ip.ex
@@ -1,0 +1,8 @@
+defmodule Nerves.NetworkNG.IP do
+  def link(args \\ []) do
+    case System.cmd("ip", ["link"] ++ args, stderr_to_stdout: true) do
+      {output, 0} -> {:ok, output}
+      {error, 1} -> {:error, error}
+    end
+  end
+end


### PR DESCRIPTION
Gets a list of interfaces from the current system.

Not sure how naive this is, but from my tests it works. Also, I can see moving more parsing into the IP.link function, but that seemed a little complex for our initial goals, but I can do that.